### PR TITLE
解决Github Action 使用ubuntu-latest环境下无法下载python依赖导致无法执行RQ签到问题

### DIFF
--- a/.github/workflows/rq-sigin-sync.yml
+++ b/.github/workflows/rq-sigin-sync.yml
@@ -9,7 +9,7 @@ env:
   GITHUB_EMAIL: ${{ secrets.GITHUBS_EMAIL }}
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
解决Github Action 使用ubuntu-latest环境下无法下载python依赖导致无法执行RQ签到问题